### PR TITLE
Automatically detect AVX2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ If you use this implementation or parts of it please cite:
 ```
 pip install git+https://github.com/wiktorowski211/deeds-registration
 ```
+The build automatically detects if your CPU supports AVX2 instructions and uses
+them when available. You can force or disable AVX2 usage with the `USE_AVX2`
+environment variable (set `USE_AVX2=1` to force enable or `USE_AVX2=0` to
+disable):
+
+```
+USE_AVX2=0 pip install git+https://github.com/wiktorowski211/deeds-registration
+```
 
 ## Usage
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-SimpleITK==2.1.1
-cython==0.29.28
-numpy==1.19.5
+SimpleITK
+cython
+numpy


### PR DESCRIPTION
## Summary
- detect AVX2 features using `py-cpuinfo` when available
- allow overriding AVX2 usage with `USE_AVX2` env var
- document automatic detection in README
- unpin dependencies and bump version to 1.0.3

## Testing
- `python -m pip install -q -r requirements.txt`
- `python setup.py build_ext --inplace`
- `python -m unittest -v`