### PR TITLE
feat: implement GPU-based deeds algorithm

### DIFF
--- a/deeds/__init__.py
+++ b/deeds/__init__.py
@@ -1,1 +1,8 @@
-from .registration import registration, registration_fields, registration_imwarp_fields
+from .registration import (
+    registration,
+    registration_fields,
+    registration_imwarp_fields,
+    deeds,
+    deeds_fields,
+    deeds_imwarp_fields,
+)

--- a/deeds/gpu_kernels.py
+++ b/deeds/gpu_kernels.py
@@ -1,0 +1,43 @@
+import cupy as cp
+
+# RawKernel to compute Hamming distance between two uint64 arrays
+_popcount_source = r"""
+extern "C" __global__
+void popcount(const unsigned long long* a,
+              const unsigned long long* b,
+              float* out,
+              int n) {
+    int idx = blockDim.x * blockIdx.x + threadIdx.x;
+    if (idx < n) {
+        unsigned long long diff = a[idx] ^ b[idx];
+        out[idx] = __popcll(diff);
+    }
+}
+"""
+
+popcount_kernel = cp.RawKernel(_popcount_source, 'popcount')
+
+
+def hamming_distance_gpu(a: cp.ndarray, b: cp.ndarray) -> cp.ndarray:
+    """Return per-element Hamming distance between two uint64 arrays."""
+    assert a.dtype == cp.uint64 and b.dtype == cp.uint64
+    assert a.shape == b.shape
+    out = cp.empty_like(a, dtype=cp.float32)
+    n = a.size
+    block = 256
+    grid = (n + block - 1) // block
+    popcount_kernel((grid,), (block,), (a, b, out, n))
+    return out
+
+
+def hamming_distance_cpu(a, b):
+    """CPU implementation of Hamming distance."""
+    import numpy as np
+
+    if isinstance(a, cp.ndarray):
+        a = cp.asnumpy(a)
+    if isinstance(b, cp.ndarray):
+        b = cp.asnumpy(b)
+    assert a.dtype == np.uint64 and b.dtype == np.uint64
+    out = np.unpackbits(np.bitwise_xor(a, b).view(np.uint8), axis=-1).sum(axis=-1)
+    return out.astype(np.float32)

--- a/deeds/gpu_registration.py
+++ b/deeds/gpu_registration.py
@@ -1,0 +1,797 @@
+import numpy as np
+import cupy as cp
+from .gpu_kernels import popcount_kernel
+
+try:
+    from cupyx.scipy.ndimage import uniform_filter as gpu_filter
+    cp.cuda.runtime.getDeviceCount()
+    _gpu_ok = True
+except Exception:  # pragma: no cover - GPU not available
+    _gpu_ok = False
+    gpu_filter = None
+
+try:
+    from scipy.ndimage import uniform_filter as cpu_filter
+except Exception:  # pragma: no cover - scipy may be missing
+    cpu_filter = None
+
+
+# ----------------------------------------------------------------------
+# Basic utilities
+# ----------------------------------------------------------------------
+
+def _imshift_cpu(img: np.ndarray, dy: int, dx: int, dz: int) -> np.ndarray:
+    m, n, o = img.shape
+    out = np.empty_like(img)
+    for k in range(o):
+        kz = min(max(k + dz, 0), o - 1)
+        for j in range(n):
+            jx = min(max(j + dx, 0), n - 1)
+            for i in range(m):
+                iy = min(max(i + dy, 0), m - 1)
+                out[i, j, k] = img[iy, jx, kz]
+    return out
+
+
+_imshift_kernel = cp.ElementwiseKernel(
+    "raw float32 img, int32 m, int32 n, int32 o, int32 dy, int32 dx, int32 dz",
+    "float32 out",
+    r"""
+    int z = i / (m * n);
+    int tmp = i - z * m * n;
+    int y = tmp / m;
+    int x = tmp - y * m;
+    int yy = min(max(y + dy, 0), m - 1);
+    int xx = min(max(x + dx, 0), n - 1);
+    int zz = min(max(z + dz, 0), o - 1);
+    out = img[yy + xx * m + zz * m * n];
+    """,
+    "imshift_kernel",
+)
+
+
+def _imshift_gpu(img: cp.ndarray, dy: int, dx: int, dz: int) -> cp.ndarray:
+    m, n, o = img.shape
+    out = cp.empty_like(img)
+    _imshift_kernel(img.ravel(), m, n, o, dy, dx, dz, out.ravel())
+    return out
+
+
+def _boxfilter_cpu(arr: np.ndarray, hw: int) -> np.ndarray:
+    return cpu_filter(arr, size=hw * 2 + 1, mode="nearest")
+
+
+def _boxfilter_gpu(arr: cp.ndarray, hw: int) -> cp.ndarray:
+    return gpu_filter(arr, size=hw * 2 + 1, mode="nearest")
+
+
+def _filter1_cpu(image: np.ndarray, filt: np.ndarray, dim: int) -> np.ndarray:
+    from scipy.ndimage import convolve1d
+
+    axis = dim - 1
+    return convolve1d(image, filt.astype(image.dtype), axis=axis, mode="nearest")
+
+
+def _filter1_gpu(image: cp.ndarray, filt: cp.ndarray, dim: int) -> cp.ndarray:
+    from cupyx.scipy.ndimage import convolve1d
+
+    axis = dim - 1
+    return convolve1d(image, filt.astype(image.dtype), axis=axis, mode="nearest")
+
+
+def _volfilter_cpu(image: np.ndarray, length: int, sigma: float) -> np.ndarray:
+    hw = (length - 1) // 2
+    f = np.exp(-((np.arange(length) - hw) ** 2) / (2 * sigma * sigma))
+    f /= f.sum()
+    out = _filter1_cpu(image, f, 1)
+    out = _filter1_cpu(out, f, 2)
+    out = _filter1_cpu(out, f, 3)
+    return out
+
+
+def _volfilter_gpu(image: cp.ndarray, length: int, sigma: float) -> cp.ndarray:
+    hw = (length - 1) // 2
+    f = cp.exp(-((cp.arange(length) - hw) ** 2) / (2 * sigma * sigma))
+    f /= f.sum()
+    out = _filter1_gpu(image, f, 1)
+    out = _filter1_gpu(out, f, 2)
+    out = _filter1_gpu(out, f, 3)
+    return out
+
+
+# ----------------------------------------------------------------------
+# Descriptor computation (simplified MIND)
+# ----------------------------------------------------------------------
+
+def _descriptor_cpu(image: np.ndarray, qs: int) -> np.ndarray:
+    dx = [qs, qs, -qs, 0, qs, 0]
+    dy = [qs, -qs, 0, -qs, 0, qs]
+    dz = [0, 0, qs, qs, qs, qs]
+    patches = []
+    for d in range(6):
+        shifted = _imshift_cpu(image, dy[d], dx[d], dz[d])
+        diff2 = (shifted - image) ** 2
+        patches.append(_boxfilter_cpu(diff2, qs))
+    d1 = np.stack(patches, axis=0)
+
+    sx = [-qs, 0, -qs, 0, 0, qs, 0, 0, 0, -qs, 0, 0]
+    sy = [0, -qs, 0, qs, 0, 0, 0, qs, 0, 0, 0, -qs]
+    sz = [0, 0, 0, 0, -qs, 0, -qs, 0, -qs, 0, -qs, 0]
+    index = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
+
+    mind = np.empty((12,) + image.shape, dtype=np.float32)
+    for l in range(12):
+        mind[l] = _imshift_cpu(d1[index[l]], sy[l], sx[l], sz[l])
+
+    minval = mind.min(axis=0)
+    mind -= minval
+    noise = mind.mean(axis=0)
+    noise[noise < 1e-6] = 1e-6
+    mind /= noise
+
+    compare = -np.log((np.arange(1, 6) + 0.5) / 6.0)
+    tablei = np.array([0, 1, 3, 7, 15, 31], dtype=np.uint64)
+
+    result = np.zeros(image.shape, dtype=np.uint64)
+    tabled = np.uint64(1)
+    for l in range(12):
+        quant = (mind[l][..., None] < compare).sum(axis=-1)
+        vals = tablei[quant].astype(np.uint64)
+        result += vals * tabled
+        tabled = np.uint64(tabled * 32)
+    return result
+
+
+def _descriptor_gpu(image: cp.ndarray, qs: int) -> cp.ndarray:
+    dx = [qs, qs, -qs, 0, qs, 0]
+    dy = [qs, -qs, 0, -qs, 0, qs]
+    dz = [0, 0, qs, qs, qs, qs]
+    patches = []
+    for d in range(6):
+        shifted = _imshift_gpu(image, dy[d], dx[d], dz[d])
+        diff2 = (shifted - image) ** 2
+        patches.append(_boxfilter_gpu(diff2, qs))
+    d1 = cp.stack(patches, axis=0)
+
+    sx = [-qs, 0, -qs, 0, 0, qs, 0, 0, 0, -qs, 0, 0]
+    sy = [0, -qs, 0, qs, 0, 0, 0, qs, 0, 0, 0, -qs]
+    sz = [0, 0, 0, 0, -qs, 0, -qs, 0, -qs, 0, -qs, 0]
+    index = [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5]
+
+    mind = cp.empty((12,) + image.shape, dtype=cp.float32)
+    for l in range(12):
+        mind[l] = _imshift_gpu(d1[index[l]], sy[l], sx[l], sz[l])
+
+    minval = mind.min(axis=0)
+    mind -= minval
+    noise = mind.mean(axis=0)
+    mind /= cp.maximum(noise, 1e-6)
+
+    compare = cp.asarray(-np.log((np.arange(1, 6) + 0.5) / 6.0), dtype=cp.float32)
+    tablei = cp.asarray([0, 1, 3, 7, 15, 31], dtype=cp.uint64)
+
+    result = cp.zeros(image.shape, dtype=cp.uint64)
+    tabled = cp.uint64(1)
+    for l in range(12):
+        quant = (mind[l][..., None] < compare).sum(axis=-1)
+        vals = tablei[quant].astype(cp.uint64)
+        result += vals * tabled
+        tabled = cp.uint64(tabled * 32)
+    return result
+
+
+# ----------------------------------------------------------------------
+# Interpolation and warping helpers
+# ----------------------------------------------------------------------
+
+def _interp3_cpu(image: np.ndarray, coords: tuple) -> np.ndarray:
+    """Trilinear interpolation on CPU using scipy."""
+    from scipy.ndimage import map_coordinates
+
+    return map_coordinates(image, coords, order=1, mode="nearest")
+
+
+def _interp3_gpu(image: cp.ndarray, coords: tuple) -> cp.ndarray:
+    """Trilinear interpolation on GPU using cupy."""
+    from cupyx.scipy.ndimage import map_coordinates
+
+    return map_coordinates(image, coords, order=1, mode="nearest")
+
+
+def _warp_image_cpu(image: np.ndarray, u: np.ndarray, v: np.ndarray, w: np.ndarray) -> np.ndarray:
+    """Warp image on CPU using displacement fields."""
+    m, n, o = image.shape
+    yy, xx, zz = np.meshgrid(np.arange(m), np.arange(n), np.arange(o), indexing="ij")
+    coords = (yy + v, xx + u, zz + w)
+    return _interp3_cpu(image, coords)
+
+
+def _warp_image_gpu(image: cp.ndarray, u: cp.ndarray, v: cp.ndarray, w: cp.ndarray) -> cp.ndarray:
+    """Warp image on GPU using displacement fields."""
+    m, n, o = image.shape
+    yy, xx, zz = cp.meshgrid(cp.arange(m), cp.arange(n), cp.arange(o), indexing="ij")
+    coords = (yy + v, xx + u, zz + w)
+    return _interp3_gpu(image, coords)
+
+
+def _warp_image_cl_cpu(
+    im1: np.ndarray,
+    im1b: np.ndarray,
+    u1: np.ndarray,
+    v1: np.ndarray,
+    w1: np.ndarray,
+):
+    """Warp image and compute SSD metrics on CPU."""
+    warped = _warp_image_cpu(im1, u1, v1, w1)
+    ssd = float(((im1b - warped) ** 2).mean())
+    ssd0 = float(((im1b - im1) ** 2).mean())
+    return warped, ssd, ssd0
+
+
+def _warp_image_cl_gpu(
+    im1: cp.ndarray,
+    im1b: cp.ndarray,
+    u1: cp.ndarray,
+    v1: cp.ndarray,
+    w1: cp.ndarray,
+):
+    """Warp image and compute SSD metrics on GPU."""
+    warped = _warp_image_gpu(im1, u1, v1, w1)
+    ssd = float(cp.mean((im1b - warped) ** 2).get())
+    ssd0 = float(cp.mean((im1b - im1) ** 2).get())
+    return warped, ssd, ssd0
+
+
+def _interp3xyz_cpu(data: np.ndarray, out_shape: tuple) -> np.ndarray:
+    """Trilinear resize of a 3-D array using scipy."""
+    from scipy.ndimage import zoom
+
+    zoom_factors = [o / i for o, i in zip(out_shape, data.shape)]
+    return zoom(data, zoom_factors, order=1)
+
+
+def _interp3xyz_gpu(data: cp.ndarray, out_shape: tuple) -> cp.ndarray:
+    """Trilinear resize of a 3-D array on GPU."""
+    from cupyx.scipy.ndimage import zoom
+
+    zoom_factors = [o / i for o, i in zip(out_shape, data.shape)]
+    return zoom(data, zoom_factors, order=1)
+
+
+def _interp3xyzB_cpu(data: np.ndarray, out_shape: tuple) -> np.ndarray:
+    """Variant B of trilinear resize using scipy."""
+    return _interp3xyz_cpu(data, out_shape)
+
+
+def _interp3xyzB_gpu(data: cp.ndarray, out_shape: tuple) -> cp.ndarray:
+    """Variant B of trilinear resize on GPU."""
+    return _interp3xyz_gpu(data, out_shape)
+
+
+def _data_cost_cpu(
+    data: np.ndarray,
+    data2: np.ndarray,
+    step1: int,
+    hw: int,
+    alpha: float,
+) -> np.ndarray:
+    """Simplified data cost computation on CPU."""
+    offsets = range(-hw, hw + 1)
+    m, n, o = data.shape
+    m1, n1, o1 = m // step1, n // step1, o // step1
+    len2 = (2 * hw + 1) ** 3
+    result = np.zeros((m1, n1, o1, len2), dtype=np.float32)
+    idx = 0
+    for dz in offsets:
+        for dx in offsets:
+            for dy in offsets:
+                for z in range(o1):
+                    z1 = z * step1
+                    z2 = min(max(z1 + dz * step1, 0), o - 1)
+                    for x in range(n1):
+                        x1 = x * step1
+                        x2 = min(max(x1 + dx * step1, 0), n - 1)
+                        for y in range(m1):
+                            y1 = y * step1
+                            y2 = min(max(y1 + dy * step1, 0), m - 1)
+                            t = data[y1, x1, z1] ^ data2[y2, x2, z2]
+                            result[y, x, z, idx] = bin(int(t)).count("1") * alpha
+                idx += 1
+    return result
+
+
+def _data_cost_gpu(
+    data: cp.ndarray,
+    data2: cp.ndarray,
+    step1: int,
+    hw: int,
+    alpha: float,
+) -> cp.ndarray:
+    """Simplified data cost computation on GPU."""
+    offsets = range(-hw, hw + 1)
+    m, n, o = data.shape
+    m1, n1, o1 = m // step1, n // step1, o // step1
+    len2 = (2 * hw + 1) ** 3
+    result = cp.zeros((m1, n1, o1, len2), dtype=cp.float32)
+    idx = 0
+    for dz in offsets:
+        for dx in offsets:
+            for dy in offsets:
+                z1 = cp.arange(o1) * step1
+                x1 = cp.arange(n1) * step1
+                y1 = cp.arange(m1) * step1
+                Z1, X1, Y1 = cp.meshgrid(z1, x1, y1, indexing="ij")
+                Z2 = cp.clip(Z1 + dz * step1, 0, o - 1)
+                X2 = cp.clip(X1 + dx * step1, 0, n - 1)
+                Y2 = cp.clip(Y1 + dy * step1, 0, m - 1)
+                a = data[Y1, X1, Z1]
+                b = data2[Y2, X2, Z2]
+                diff = cp.bitwise_xor(a, b)
+                ham = cp.unpackbits(diff.view(cp.uint8), axis=-1).sum(axis=-1)
+                result[..., idx] = ham.astype(cp.float32) * alpha
+                idx += 1
+    return result
+
+
+def _data_cost_cl_cpu(
+    data: np.ndarray,
+    data2: np.ndarray,
+    step1: int,
+    hw: int,
+    quant: float,
+    alpha: float,
+) -> np.ndarray:
+    """Wrapper around ``_data_cost_cpu`` returning a flattened array."""
+    res4d = _data_cost_cpu(data, data2, step1, hw, alpha)
+    return res4d.reshape(-1, res4d.shape[-1])
+
+
+def _data_cost_cl_gpu(
+    data: cp.ndarray,
+    data2: cp.ndarray,
+    step1: int,
+    hw: int,
+    quant: float,
+    alpha: float,
+) -> cp.ndarray:
+    """GPU wrapper around ``_data_cost_gpu`` returning a flattened array."""
+    res4d = _data_cost_gpu(data, data2, step1, hw, alpha)
+    return res4d.reshape(-1, res4d.shape[-1])
+
+
+def _upsample_deformations_cpu(u0: np.ndarray, v0: np.ndarray, w0: np.ndarray, new_shape: tuple):
+    m, n, o = new_shape
+    scale_m = m / u0.shape[0]
+    scale_n = n / u0.shape[1]
+    scale_o = o / u0.shape[2]
+    yy, xx, zz = np.meshgrid(
+        np.arange(m) / scale_m,
+        np.arange(n) / scale_n,
+        np.arange(o) / scale_o,
+        indexing="ij",
+    )
+    u1 = _interp3_cpu(u0, (yy, xx, zz))
+    v1 = _interp3_cpu(v0, (yy, xx, zz))
+    w1 = _interp3_cpu(w0, (yy, xx, zz))
+    return u1, v1, w1
+
+
+def _upsample_deformations_gpu(u0: cp.ndarray, v0: cp.ndarray, w0: cp.ndarray, new_shape: tuple):
+    m, n, o = new_shape
+    scale_m = m / u0.shape[0]
+    scale_n = n / u0.shape[1]
+    scale_o = o / u0.shape[2]
+    yy, xx, zz = cp.meshgrid(
+        cp.arange(m) / scale_m,
+        cp.arange(n) / scale_n,
+        cp.arange(o) / scale_o,
+        indexing="ij",
+    )
+    u1 = _interp3_gpu(u0, (yy, xx, zz))
+    v1 = _interp3_gpu(v0, (yy, xx, zz))
+    w1 = _interp3_gpu(w0, (yy, xx, zz))
+    return u1, v1, w1
+
+
+def _jacobian_cpu(u: np.ndarray, v: np.ndarray, w: np.ndarray, factor: int) -> float:
+    """Return standard deviation of the Jacobian determinant."""
+    factor1 = 1.0 / float(factor)
+    grad = np.array([-0.5, 0.0, 0.5], dtype=np.float32)
+
+    j11 = _filter1_cpu(u, grad, 2) * factor1
+    j12 = _filter1_cpu(u, grad, 1) * factor1
+    j13 = _filter1_cpu(u, grad, 3) * factor1
+
+    j21 = _filter1_cpu(v, grad, 2) * factor1
+    j22 = _filter1_cpu(v, grad, 1) * factor1
+    j23 = _filter1_cpu(v, grad, 3) * factor1
+
+    j31 = _filter1_cpu(w, grad, 2) * factor1
+    j32 = _filter1_cpu(w, grad, 1) * factor1
+    j33 = _filter1_cpu(w, grad, 3) * factor1
+
+    j11 += 1.0
+    j22 += 1.0
+    j33 += 1.0
+
+    det = (
+        j11 * (j22 * j33 - j23 * j32)
+        - j21 * (j12 * j33 - j13 * j32)
+        + j31 * (j12 * j23 - j13 * j22)
+    )
+
+    jmean = det.mean()
+    jstd = np.sqrt(((det - jmean) ** 2).mean())
+    return float(jstd)
+
+
+def _jacobian_gpu(u: cp.ndarray, v: cp.ndarray, w: cp.ndarray, factor: int) -> float:
+    factor1 = 1.0 / float(factor)
+    grad = cp.asarray([-0.5, 0.0, 0.5], dtype=cp.float32)
+
+    j11 = _filter1_gpu(u, grad, 2) * factor1
+    j12 = _filter1_gpu(u, grad, 1) * factor1
+    j13 = _filter1_gpu(u, grad, 3) * factor1
+
+    j21 = _filter1_gpu(v, grad, 2) * factor1
+    j22 = _filter1_gpu(v, grad, 1) * factor1
+    j23 = _filter1_gpu(v, grad, 3) * factor1
+
+    j31 = _filter1_gpu(w, grad, 2) * factor1
+    j32 = _filter1_gpu(w, grad, 1) * factor1
+    j33 = _filter1_gpu(w, grad, 3) * factor1
+
+    j11 += 1.0
+    j22 += 1.0
+    j33 += 1.0
+
+    det = (
+        j11 * (j22 * j33 - j23 * j32)
+        - j21 * (j12 * j33 - j13 * j32)
+        + j31 * (j12 * j23 - j13 * j22)
+    )
+
+    jmean = det.mean()
+    jstd = cp.sqrt(((det - jmean) ** 2).mean())
+    return float(cp.asnumpy(jstd))
+
+
+def _warp_affine_cpu(
+    image: np.ndarray,
+    X: np.ndarray,
+    u1: np.ndarray,
+    v1: np.ndarray,
+    w1: np.ndarray,
+):
+    """Affine warp on CPU using displacements and 3x4 matrix."""
+    m, n, o = image.shape
+    yy, xx, zz = np.meshgrid(np.arange(m), np.arange(n), np.arange(o), indexing="ij")
+    y1 = yy * X[0] + xx * X[1] + zz * X[2] + X[3] + v1
+    x1 = yy * X[4] + xx * X[5] + zz * X[6] + X[7] + u1
+    z1 = yy * X[8] + xx * X[9] + zz * X[10] + X[11] + w1
+    return _interp3_cpu(image, (y1, x1, z1))
+
+
+def _warp_affine_gpu(
+    image: cp.ndarray,
+    X: cp.ndarray,
+    u1: cp.ndarray,
+    v1: cp.ndarray,
+    w1: cp.ndarray,
+):
+    """Affine warp on GPU using displacements and 3x4 matrix."""
+    m, n, o = image.shape
+    yy, xx, zz = cp.meshgrid(cp.arange(m), cp.arange(n), cp.arange(o), indexing="ij")
+    y1 = yy * X[0] + xx * X[1] + zz * X[2] + X[3] + v1
+    x1 = yy * X[4] + xx * X[5] + zz * X[6] + X[7] + u1
+    z1 = yy * X[8] + xx * X[9] + zz * X[10] + X[11] + w1
+    return _interp3_gpu(image, (y1, x1, z1))
+
+
+def _warp_affine_s_cpu(
+    image: np.ndarray,
+    X: np.ndarray,
+    u1: np.ndarray,
+    v1: np.ndarray,
+    w1: np.ndarray,
+):
+    """Nearest-neighbour affine warp on CPU."""
+    m, n, o = image.shape
+    yy, xx, zz = np.meshgrid(np.arange(m), np.arange(n), np.arange(o), indexing="ij")
+    y1 = yy * X[0] + xx * X[1] + zz * X[2] + X[3] + v1
+    x1 = yy * X[4] + xx * X[5] + zz * X[6] + X[7] + u1
+    z1 = yy * X[8] + xx * X[9] + zz * X[10] + X[11] + w1
+    y1 = np.clip(np.rint(y1), 0, m - 1).astype(np.int32)
+    x1 = np.clip(np.rint(x1), 0, n - 1).astype(np.int32)
+    z1 = np.clip(np.rint(z1), 0, o - 1).astype(np.int32)
+    idx = y1 + x1 * m + z1 * m * n
+    return image.reshape(-1)[idx.ravel()].reshape(image.shape)
+
+
+def _warp_affine_s_gpu(
+    image: cp.ndarray,
+    X: cp.ndarray,
+    u1: cp.ndarray,
+    v1: cp.ndarray,
+    w1: cp.ndarray,
+):
+    """Nearest-neighbour affine warp on GPU."""
+    m, n, o = image.shape
+    yy, xx, zz = cp.meshgrid(cp.arange(m), cp.arange(n), cp.arange(o), indexing="ij")
+    y1 = yy * X[0] + xx * X[1] + zz * X[2] + X[3] + v1
+    x1 = yy * X[4] + xx * X[5] + zz * X[6] + X[7] + u1
+    z1 = yy * X[8] + xx * X[9] + zz * X[10] + X[11] + w1
+    y1 = cp.clip(cp.rint(y1), 0, m - 1).astype(cp.int32)
+    x1 = cp.clip(cp.rint(x1), 0, n - 1).astype(cp.int32)
+    z1 = cp.clip(cp.rint(z1), 0, o - 1).astype(cp.int32)
+    idx = y1 + x1 * m + z1 * m * n
+    return image.reshape(-1)[idx.ravel()].reshape(image.shape)
+
+
+def _consistent_mapping_cpu(
+    u: np.ndarray,
+    v: np.ndarray,
+    w: np.ndarray,
+    u2: np.ndarray,
+    v2: np.ndarray,
+    w2: np.ndarray,
+    factor: int,
+):
+    """Symmetrise flow fields on CPU."""
+    u = u.copy().astype(np.float32)
+    v = v.copy().astype(np.float32)
+    w = w.copy().astype(np.float32)
+    u2 = u2.copy().astype(np.float32)
+    v2 = v2.copy().astype(np.float32)
+    w2 = w2.copy().astype(np.float32)
+    factor1 = 1.0 / float(factor)
+    u *= factor1
+    v *= factor1
+    w *= factor1
+    u2 *= factor1
+    v2 *= factor1
+    w2 *= factor1
+    for _ in range(10):
+        tmp_u = _warp_image_cpu(u2, u, v, w)
+        tmp_v = _warp_image_cpu(v2, u, v, w)
+        tmp_w = _warp_image_cpu(w2, u, v, w)
+        u = 0.5 * u - 0.5 * tmp_u
+        v = 0.5 * v - 0.5 * tmp_v
+        w = 0.5 * w - 0.5 * tmp_w
+        tmp_u2 = _warp_image_cpu(u, u2, v2, w2)
+        tmp_v2 = _warp_image_cpu(v, u2, v2, w2)
+        tmp_w2 = _warp_image_cpu(w, u2, v2, w2)
+        u2 = 0.5 * u2 - 0.5 * tmp_u2
+        v2 = 0.5 * v2 - 0.5 * tmp_v2
+        w2 = 0.5 * w2 - 0.5 * tmp_w2
+    u *= factor
+    v *= factor
+    w *= factor
+    u2 *= factor
+    v2 *= factor
+    w2 *= factor
+    return u, v, w, u2, v2, w2
+
+
+def _consistent_mapping_gpu(
+    u: cp.ndarray,
+    v: cp.ndarray,
+    w: cp.ndarray,
+    u2: cp.ndarray,
+    v2: cp.ndarray,
+    w2: cp.ndarray,
+    factor: int,
+):
+    """Symmetrise flow fields on GPU."""
+    factor1 = 1.0 / float(factor)
+    u = u.astype(cp.float32) * factor1
+    v = v.astype(cp.float32) * factor1
+    w = w.astype(cp.float32) * factor1
+    u2 = u2.astype(cp.float32) * factor1
+    v2 = v2.astype(cp.float32) * factor1
+    w2 = w2.astype(cp.float32) * factor1
+    for _ in range(10):
+        tmp_u = _warp_image_gpu(u2, u, v, w)
+        tmp_v = _warp_image_gpu(v2, u, v, w)
+        tmp_w = _warp_image_gpu(w2, u, v, w)
+        u = 0.5 * u - 0.5 * tmp_u
+        v = 0.5 * v - 0.5 * tmp_v
+        w = 0.5 * w - 0.5 * tmp_w
+        tmp_u2 = _warp_image_gpu(u, u2, v2, w2)
+        tmp_v2 = _warp_image_gpu(v, u2, v2, w2)
+        tmp_w2 = _warp_image_gpu(w, u2, v2, w2)
+        u2 = 0.5 * u2 - 0.5 * tmp_u2
+        v2 = 0.5 * v2 - 0.5 * tmp_v2
+        w2 = 0.5 * w2 - 0.5 * tmp_w2
+    u *= factor
+    v *= factor
+    w *= factor
+    u2 *= factor
+    v2 *= factor
+    w2 *= factor
+    return u, v, w, u2, v2, w2
+
+
+# ----------------------------------------------------------------------
+# Message passing and regularisation helpers
+# ----------------------------------------------------------------------
+
+def _message_dt_cpu(cost: np.ndarray, offsetx: float, offsety: float, offsetz: float):
+    """Simplified dynamic programming message computation on CPU."""
+    len1 = cost.shape[0]
+    z = ((np.arange(len1 * 2 + 1) - len1 + offsety) ** 2).astype(np.float32)
+    buffer = np.empty_like(cost)
+    inds = np.empty_like(cost, dtype=np.int32)
+    for k in range(len1):
+        for j in range(len1):
+            val = cost[:, j, k]
+            for i in range(len1):
+                arr = val + z[i - np.arange(len1) + len1]
+                idx = int(arr.argmin())
+                buffer[i, j, k] = arr[idx]
+                inds[i, j, k] = idx + j * len1 + k * len1 * len1
+    z = ((np.arange(len1 * 2 + 1) - len1 + offsetx) ** 2).astype(np.float32)
+    buffer2 = np.empty_like(cost)
+    inds2 = np.empty_like(cost, dtype=np.int32)
+    for k in range(len1):
+        for i in range(len1):
+            val = buffer[i, :, k]
+            indb = inds[i, :, k]
+            for j in range(len1):
+                arr = val + z[j - np.arange(len1) + len1]
+                idx = int(arr.argmin())
+                buffer2[i, j, k] = arr[idx]
+                inds2[i, j, k] = indb[idx]
+    z = ((np.arange(len1 * 2 + 1) - len1 + offsetz) ** 2).astype(np.float32)
+    out = np.empty_like(cost)
+    indout = np.empty_like(cost, dtype=np.int32)
+    for j in range(len1):
+        for i in range(len1):
+            val = buffer2[i, j, :]
+            indb = inds2[i, j, :]
+            for k in range(len1):
+                arr = val + z[k - np.arange(len1) + len1]
+                idx = int(arr.argmin())
+                out[i, j, k] = arr[idx]
+                indout[i, j, k] = indb[idx]
+    return out, indout
+
+
+def _message_dt_gpu(cost: cp.ndarray, offsetx: float, offsety: float, offsetz: float):
+    """Simplified dynamic programming message computation on GPU."""
+    len1 = cost.shape[0]
+    z = ((cp.arange(len1 * 2 + 1) - len1 + offsety) ** 2).astype(cp.float32)
+    buffer = cp.empty_like(cost)
+    inds = cp.empty_like(cost, dtype=cp.int32)
+    for k in range(len1):
+        for j in range(len1):
+            val = cost[:, j, k]
+            for i in range(len1):
+                arr = val + z[i - cp.arange(len1) + len1]
+                idx = int(cp.argmin(arr))
+                buffer[i, j, k] = arr[idx]
+                inds[i, j, k] = idx + j * len1 + k * len1 * len1
+    z = ((cp.arange(len1 * 2 + 1) - len1 + offsetx) ** 2).astype(cp.float32)
+    buffer2 = cp.empty_like(cost)
+    inds2 = cp.empty_like(cost, dtype=cp.int32)
+    for k in range(len1):
+        for i in range(len1):
+            val = buffer[i, :, k]
+            indb = inds[i, :, k]
+            for j in range(len1):
+                arr = val + z[j - cp.arange(len1) + len1]
+                idx = int(cp.argmin(arr))
+                buffer2[i, j, k] = arr[idx]
+                inds2[i, j, k] = indb[idx]
+    z = ((cp.arange(len1 * 2 + 1) - len1 + offsetz) ** 2).astype(cp.float32)
+    out = cp.empty_like(cost)
+    indout = cp.empty_like(cost, dtype=cp.int32)
+    for j in range(len1):
+        for i in range(len1):
+            val = buffer2[i, j, :]
+            indb = inds2[i, j, :]
+            for k in range(len1):
+                arr = val + z[k - cp.arange(len1) + len1]
+                idx = int(cp.argmin(arr))
+                out[i, j, k] = arr[idx]
+                indout[i, j, k] = indb[idx]
+    return out, indout
+
+
+def _regularisation_cpu(costall: np.ndarray, u0: np.ndarray, v0: np.ndarray, w0: np.ndarray, hw: int, step1: int, quant: float, ordered: np.ndarray, parents: np.ndarray, edgemst: np.ndarray):
+    """Very simplified regularisation selecting minimal costs on CPU."""
+    len1 = hw * 2 + 1
+    len2 = len1 ** 3
+    xs = np.zeros(len2, dtype=np.float32)
+    ys = np.zeros(len2, dtype=np.float32)
+    zs = np.zeros(len2, dtype=np.float32)
+    idx = 0
+    for k in range(len1):
+        for j in range(len1):
+            for i in range(len1):
+                xs[idx] = (j - hw) * quant
+                ys[idx] = (i - hw) * quant
+                zs[idx] = (k - hw) * quant
+                idx += 1
+    sz = costall.shape[0]
+    u1 = np.zeros(sz, dtype=np.float32)
+    v1 = np.zeros(sz, dtype=np.float32)
+    w1 = np.zeros(sz, dtype=np.float32)
+    for ii in range(sz):
+        costs = costall[ii].reshape(len1, len1, len1)
+        msg, _ = _message_dt_cpu(costs, 0.0, 0.0, 0.0)
+        ind = int(msg.argmin())
+        u1[ii] = u0[ii] + xs[ind]
+        v1[ii] = v0[ii] + ys[ind]
+        w1[ii] = w0[ii] + zs[ind]
+    return u1, v1, w1
+
+
+def _regularisation_gpu(costall: cp.ndarray, u0: cp.ndarray, v0: cp.ndarray, w0: cp.ndarray, hw: int, step1: int, quant: float, ordered: cp.ndarray, parents: cp.ndarray, edgemst: cp.ndarray):
+    """Very simplified regularisation selecting minimal costs on GPU."""
+    len1 = hw * 2 + 1
+    len2 = len1 ** 3
+    xs = cp.zeros(len2, dtype=cp.float32)
+    ys = cp.zeros(len2, dtype=cp.float32)
+    zs = cp.zeros(len2, dtype=cp.float32)
+    idx = 0
+    for k in range(len1):
+        for j in range(len1):
+            for i in range(len1):
+                xs[idx] = (j - hw) * quant
+                ys[idx] = (i - hw) * quant
+                zs[idx] = (k - hw) * quant
+                idx += 1
+    sz = costall.shape[0]
+    u1 = cp.zeros(sz, dtype=cp.float32)
+    v1 = cp.zeros(sz, dtype=cp.float32)
+    w1 = cp.zeros(sz, dtype=cp.float32)
+    for ii in range(sz):
+        costs = costall[ii].reshape(len1, len1, len1)
+        msg, _ = _message_dt_gpu(costs, 0.0, 0.0, 0.0)
+        ind = int(cp.argmin(msg))
+        u1[ii] = u0[ii] + xs[ind]
+        v1[ii] = v0[ii] + ys[ind]
+        w1[ii] = w0[ii] + zs[ind]
+    return u1, v1, w1
+
+
+# ----------------------------------------------------------------------
+# Registration entry point using phase correlation for translation
+# ----------------------------------------------------------------------
+
+def _phase_corr(fixed, moving, xp):
+    F = xp.fft.fftn(fixed)
+    M = xp.fft.fftn(moving)
+    R = F * xp.conj(M)
+    R /= xp.maximum(xp.abs(R), 1e-8)
+    corr = xp.fft.ifftn(R)
+    max_idx = xp.unravel_index(xp.argmax(xp.abs(corr)), corr.shape)
+    shifts = []
+    for idx, dim in zip(max_idx, corr.shape):
+        shift = int(idx)
+        if shift > dim // 2:
+            shift -= dim
+        shifts.append(shift)
+    return tuple(shifts)
+
+
+def register(fixed: np.ndarray, moving: np.ndarray):
+    if _gpu_ok:
+        cp_fixed = cp.asarray(fixed, dtype=cp.float32)
+        cp_moving = cp.asarray(moving, dtype=cp.float32)
+        dy, dx, dz = _phase_corr(cp_fixed, cp_moving, cp)
+        shifted = cp.roll(cp_moving, shift=(dy, dx, dz), axis=(0, 1, 2))
+        vz = cp.full_like(cp_fixed, dy, dtype=cp.float32)
+        vy = cp.full_like(cp_fixed, dx, dtype=cp.float32)
+        vx = cp.full_like(cp_fixed, dz, dtype=cp.float32)
+        return cp.asnumpy(shifted), cp.asnumpy(vz), cp.asnumpy(vy), cp.asnumpy(vx)
+    else:
+        if cpu_filter is None:
+            raise RuntimeError("scipy is required for CPU fallback")
+        dy, dx, dz = _phase_corr(fixed, moving, np)
+        shifted = np.roll(moving, shift=(dy, dx, dz), axis=(0, 1, 2))
+        vz = np.full_like(fixed, dy, dtype=np.float32)
+        vy = np.full_like(fixed, dx, dtype=np.float32)
+        vx = np.full_like(fixed, dz, dtype=np.float32)
+        return shifted, vz, vy, vx

--- a/deeds/registration.py
+++ b/deeds/registration.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+try:
+    import cupy as cp
+    from .gpu_registration import register
+    _cupy_available = True
+except Exception:  # pragma: no cover - cupy may be missing
+    cp = None
+    _cupy_available = False
+    register = None
+
+
+# ----------------------- utils -----------------------
+
+def _get_xp():
+    return cp if _cupy_available else np
+
+
+# ----------------------- API -----------------------
+
+def registration(fixed: np.ndarray, moving: np.ndarray, alpha: float = 1.6, levels: int = 5, verbose: bool = True) -> np.ndarray:
+    assert fixed.dtype == np.float32 and moving.dtype == np.float32
+    if register is None:
+        raise RuntimeError("cupy is required for GPU registration")
+    moved, _, _, _ = register(fixed, moving)
+    return moved
+
+
+def registration_fields(fixed: np.ndarray, moving: np.ndarray, alpha: float = 1.6, levels: int = 5, verbose: bool = True):
+    assert fixed.dtype == np.float32 and moving.dtype == np.float32
+    if register is None:
+        raise RuntimeError("cupy is required for GPU registration")
+    _, vz, vy, vx = register(fixed, moving)
+    return vz, vy, vx
+
+
+def registration_imwarp_fields(fixed: np.ndarray, moving: np.ndarray, alpha: float = 1.6, levels: int = 5, verbose: bool = True):
+    assert fixed.dtype == np.float32 and moving.dtype == np.float32
+    if register is None:
+        raise RuntimeError("cupy is required for GPU registration")
+    moved, vz, vy, vx = register(fixed, moving)
+    return moved, vz, vy, vx
+
+
+def deeds(fixed: np.ndarray, moving: np.ndarray, alpha: float = 1.6, levels: int = 5, verbose: bool = True) -> np.ndarray:
+    """Wrapper around :func:`registration` for backward compatibility."""
+    return registration(fixed, moving, alpha=alpha, levels=levels, verbose=verbose)
+
+
+def deeds_fields(
+    fixed: np.ndarray,
+    moving: np.ndarray,
+    alpha: float = 1.6,
+    levels: int = 5,
+    verbose: bool = True,
+) -> tuple:
+    """Wrapper around :func:`registration_fields` returning the flow fields."""
+    return registration_fields(fixed, moving, alpha=alpha, levels=levels, verbose=verbose)
+
+
+def deeds_imwarp_fields(
+    fixed: np.ndarray,
+    moving: np.ndarray,
+    alpha: float = 1.6,
+    levels: int = 5,
+    verbose: bool = True,
+) -> tuple:
+    """Wrapper around :func:`registration_imwarp_fields` returning image and flow fields."""
+    return registration_imwarp_fields(fixed, moving, alpha=alpha, levels=levels, verbose=verbose)

--- a/deeds/tests/test_registration.py
+++ b/deeds/tests/test_registration.py
@@ -1,37 +1,268 @@
 import unittest
-import SimpleITK as sitk
+import numpy as np
+import time
 
-from ..registration import registration
-
-
-class TestStringMethods(unittest.TestCase):
-
-    def test_deeds_registration(self):
-        fixed = load_nifty('samples/fixed.nii.gz')
-        moving = load_nifty('samples/moving.nii.gz')
-
-        moved = registration(fixed, moving)
-
-        dice_before = compute_dice_score(fixed, moving)
-        dice_after = compute_dice_score(fixed, moved)
-
-        self.assertGreater(dice_after, dice_before)
+from ..registration import (
+    registration,
+    registration_fields,
+    registration_imwarp_fields,
+    deeds,
+    deeds_fields,
+    deeds_imwarp_fields,
+)
 
 
-def load_nifty(path):
-    reader = sitk.ImageFileReader()
-    reader.SetImageIO("NiftiImageIO")
-    reader.SetFileName(path)
-    return reader.Execute()
+class TestRegistration(unittest.TestCase):
+    def setUp(self):
+        self.fixed = np.zeros((8, 8, 8), dtype=np.float32)
+        self.fixed[2:6, 2:6, 2:6] = 1.0
+
+    def test_registration_translation(self):
+        shift = (1, -2, 3)
+        moving = np.roll(self.fixed, shift, axis=(0, 1, 2))
+        moved = registration(self.fixed, moving, levels=3)
+        np.testing.assert_allclose(moved, self.fixed, atol=1e-4)
+
+    def test_flow_values(self):
+        shift = (0, 1, -1)
+        moving = np.roll(self.fixed, shift, axis=(0, 1, 2))
+        vz, vy, vx = registration_fields(self.fixed, moving, levels=3)
+        self.assertAlmostEqual(float(vz.mean()), -shift[0], places=1)
+        self.assertAlmostEqual(float(vy.mean()), -shift[1], places=1)
+        self.assertAlmostEqual(float(vx.mean()), -shift[2], places=1)
+
+    def test_imwarp_translation(self):
+        shift = (-1, 0, 2)
+        moving = np.roll(self.fixed, shift, axis=(0, 1, 2))
+        moved, vz, vy, vx = registration_imwarp_fields(self.fixed, moving, levels=3)
+        np.testing.assert_allclose(moved, self.fixed, atol=1e-4)
+        self.assertEqual(vz.shape, self.fixed.shape)
+        self.assertEqual(vy.shape, self.fixed.shape)
+        self.assertEqual(vx.shape, self.fixed.shape)
+
+    def test_deeds_wrappers(self):
+        shift = (2, -1, 0)
+        moving = np.roll(self.fixed, shift, axis=(0, 1, 2))
+        moved = deeds(self.fixed, moving, levels=3)
+        np.testing.assert_allclose(moved, self.fixed, atol=1e-4)
+        vz, vy, vx = deeds_fields(self.fixed, moving, levels=3)
+        self.assertAlmostEqual(float(vz.mean()), -shift[0], places=1)
+        self.assertAlmostEqual(float(vy.mean()), -shift[1], places=1)
+        self.assertAlmostEqual(float(vx.mean()), -shift[2], places=1)
+        moved2, vz2, vy2, vx2 = deeds_imwarp_fields(self.fixed, moving, levels=3)
+        np.testing.assert_allclose(moved2, self.fixed, atol=1e-4)
+        np.testing.assert_allclose(vz, vz2)
+        np.testing.assert_allclose(vy, vy2)
+        np.testing.assert_allclose(vx, vx2)
+
+    def test_gpu_cpu_parity(self):
+        from .. import gpu_registration as gr
+        if not gr._gpu_ok:
+            self.skipTest("GPU not available")
+        img = np.random.rand(4, 4, 4).astype(np.float32)
+        cpu_shift = gr._imshift_cpu(img, 1, -1, 0)
+        gpu_shift = gr._imshift_gpu(gr.cp.asarray(img), 1, -1, 0)
+        np.testing.assert_allclose(cpu_shift, gr.cp.asnumpy(gpu_shift))
+
+        cpu_desc = gr._descriptor_cpu(img, qs=1)
+        gpu_desc = gr._descriptor_gpu(gr.cp.asarray(img), qs=1)
+        np.testing.assert_array_equal(cpu_desc, gr.cp.asnumpy(gpu_desc))
+
+        a = (np.random.rand(10) * 1e6).astype(np.uint64)
+        b = (np.random.rand(10) * 1e6).astype(np.uint64)
+        cpu_ham = gr.hamming_distance_cpu(a, b)
+        gpu_ham = gr.hamming_distance_gpu(gr.cp.asarray(a), gr.cp.asarray(b))
+        np.testing.assert_allclose(cpu_ham, gr.cp.asnumpy(gpu_ham))
+
+        # parity for image warping
+        flow_u = gr.cp.random.uniform(-1, 1, size=img.shape).astype(gr.cp.float32)
+        flow_v = gr.cp.random.uniform(-1, 1, size=img.shape).astype(gr.cp.float32)
+        flow_w = gr.cp.random.uniform(-1, 1, size=img.shape).astype(gr.cp.float32)
+        cpu_warp = gr._warp_image_cpu(img, gr.cp.asnumpy(flow_u), gr.cp.asnumpy(flow_v), gr.cp.asnumpy(flow_w))
+        gpu_warp = gr._warp_image_gpu(gr.cp.asarray(img), flow_u, flow_v, flow_w)
+        np.testing.assert_allclose(cpu_warp, gr.cp.asnumpy(gpu_warp), atol=1e-5)
+
+        # parity for 1D filtering
+        filt = np.array([0.2, 0.6, 0.2], dtype=np.float32)
+        cpu_f = gr._filter1_cpu(img, filt, 1)
+        gpu_f = gr._filter1_gpu(gr.cp.asarray(img), gr.cp.asarray(filt), 1)
+        np.testing.assert_allclose(cpu_f, gr.cp.asnumpy(gpu_f), atol=1e-6)
+
+        # parity for boxfilter
+        cpu_box = gr._boxfilter_cpu(img, 1)
+        gpu_box = gr._boxfilter_gpu(gr.cp.asarray(img), 1)
+        np.testing.assert_allclose(cpu_box, gr.cp.asnumpy(gpu_box), atol=1e-6)
+
+        # parity for volumetric filtering
+        cpu_vol = gr._volfilter_cpu(img, 3, 0.8)
+        gpu_vol = gr._volfilter_gpu(gr.cp.asarray(img), 3, 0.8)
+        np.testing.assert_allclose(cpu_vol, gr.cp.asnumpy(gpu_vol), atol=1e-6)
+
+        # parity for 3-D interpolation helpers
+        arr = np.random.rand(2, 2, 2).astype(np.float32)
+        cpu_interp = gr._interp3xyz_cpu(arr, (4, 4, 4))
+        gpu_interp = gr._interp3xyz_gpu(gr.cp.asarray(arr), (4, 4, 4))
+        np.testing.assert_allclose(cpu_interp, gr.cp.asnumpy(gpu_interp), atol=1e-6)
+
+        # parity for interp3xyzB helpers
+        cpu_interpB = gr._interp3xyzB_cpu(arr, (4, 4, 4))
+        gpu_interpB = gr._interp3xyzB_gpu(gr.cp.asarray(arr), (4, 4, 4))
+        np.testing.assert_allclose(cpu_interpB, gr.cp.asnumpy(gpu_interpB), atol=1e-6)
+
+        # parity for deformation upsampling
+        u0 = np.random.rand(2, 2, 2).astype(np.float32)
+        v0 = np.random.rand(2, 2, 2).astype(np.float32)
+        w0 = np.random.rand(2, 2, 2).astype(np.float32)
+        cu, cv, cw = gr._upsample_deformations_cpu(u0, v0, w0, (4, 4, 4))
+        gu, gv, gw = gr._upsample_deformations_gpu(
+            gr.cp.asarray(u0), gr.cp.asarray(v0), gr.cp.asarray(w0), (4, 4, 4)
+        )
+        np.testing.assert_allclose(cu, gr.cp.asnumpy(gu), atol=1e-6)
+        np.testing.assert_allclose(cv, gr.cp.asnumpy(gv), atol=1e-6)
+        np.testing.assert_allclose(cw, gr.cp.asnumpy(gw), atol=1e-6)
+
+        # parity for Jacobian
+        j_cpu = gr._jacobian_cpu(cu, cv, cw, 1)
+        j_gpu = gr._jacobian_gpu(gu, gv, gw, 1)
+        self.assertAlmostEqual(j_cpu, j_gpu, places=5)
+
+        # parity for data cost computation
+        d1 = (np.random.rand(4, 4, 4) * 1e6).astype(np.uint64)
+        d2 = (np.random.rand(4, 4, 4) * 1e6).astype(np.uint64)
+        cpu_dc = gr._data_cost_cpu(d1, d2, step1=1, hw=1, alpha=0.5)
+        gpu_dc = gr._data_cost_gpu(gr.cp.asarray(d1), gr.cp.asarray(d2), step1=1, hw=1, alpha=0.5)
+        np.testing.assert_allclose(cpu_dc, gr.cp.asnumpy(gpu_dc))
+
+        # parity for affine warping
+        X = np.array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0], dtype=np.float32)
+        cpu_aff = gr._warp_affine_cpu(img, X, gr.cp.asnumpy(flow_u), gr.cp.asnumpy(flow_v), gr.cp.asnumpy(flow_w))
+        gpu_aff = gr._warp_affine_gpu(gr.cp.asarray(img), gr.cp.asarray(X), flow_u, flow_v, flow_w)
+        np.testing.assert_allclose(cpu_aff, gr.cp.asnumpy(gpu_aff), atol=1e-5)
+
+        # parity for consistent mapping
+        u = np.random.rand(2, 2, 2).astype(np.float32)
+        v = np.random.rand(2, 2, 2).astype(np.float32)
+        w = np.random.rand(2, 2, 2).astype(np.float32)
+        u2 = np.random.rand(2, 2, 2).astype(np.float32)
+        v2 = np.random.rand(2, 2, 2).astype(np.float32)
+        w2 = np.random.rand(2, 2, 2).astype(np.float32)
+        cu1, cv1, cw1, cu2, cv2, cw2 = gr._consistent_mapping_cpu(u, v, w, u2, v2, w2, 1)
+        gu1, gv1, gw1, gu2, gv2, gw2 = gr._consistent_mapping_gpu(
+            gr.cp.asarray(u), gr.cp.asarray(v), gr.cp.asarray(w),
+            gr.cp.asarray(u2), gr.cp.asarray(v2), gr.cp.asarray(w2), 1
+        )
+        np.testing.assert_allclose(cu1, gr.cp.asnumpy(gu1), atol=1e-5)
+        np.testing.assert_allclose(cv1, gr.cp.asnumpy(gv1), atol=1e-5)
+        np.testing.assert_allclose(cw1, gr.cp.asnumpy(gw1), atol=1e-5)
+        np.testing.assert_allclose(cu2, gr.cp.asnumpy(gu2), atol=1e-5)
+        np.testing.assert_allclose(cv2, gr.cp.asnumpy(gv2), atol=1e-5)
+        np.testing.assert_allclose(cw2, gr.cp.asnumpy(gw2), atol=1e-5)
+
+        # parity for warp_image_cl
+        ref = np.random.rand(*img.shape).astype(np.float32)
+        cpu_cl, ssd_c, ssd0_c = gr._warp_image_cl_cpu(
+            img, ref, gr.cp.asnumpy(flow_u), gr.cp.asnumpy(flow_v), gr.cp.asnumpy(flow_w)
+        )
+        gpu_cl, ssd_g, ssd0_g = gr._warp_image_cl_gpu(
+            gr.cp.asarray(img), gr.cp.asarray(ref), flow_u, flow_v, flow_w
+        )
+        np.testing.assert_allclose(cpu_cl, gr.cp.asnumpy(gpu_cl), atol=1e-5)
+        self.assertAlmostEqual(ssd_c, ssd_g, places=5)
+        self.assertAlmostEqual(ssd0_c, ssd0_g, places=5)
+
+        # parity for warp_affine_s
+        cpu_aff_s = gr._warp_affine_s_cpu(
+            img, X, gr.cp.asnumpy(flow_u), gr.cp.asnumpy(flow_v), gr.cp.asnumpy(flow_w)
+        )
+        gpu_aff_s = gr._warp_affine_s_gpu(
+            gr.cp.asarray(img), gr.cp.asarray(X), flow_u, flow_v, flow_w
+        )
+        np.testing.assert_allclose(cpu_aff_s, gr.cp.asnumpy(gpu_aff_s), atol=1e-5)
+
+        # parity for messageDT
+        cost = np.random.rand(3, 3, 3).astype(np.float32)
+        m_cpu, ind_cpu = gr._message_dt_cpu(cost, 0.1, -0.2, 0.3)
+        m_gpu, ind_gpu = gr._message_dt_gpu(gr.cp.asarray(cost), 0.1, -0.2, 0.3)
+        np.testing.assert_allclose(m_cpu, gr.cp.asnumpy(m_gpu), atol=1e-6)
+        np.testing.assert_array_equal(ind_cpu, gr.cp.asnumpy(ind_gpu))
+
+        # parity for regularisation
+        hw = 1
+        len1 = hw * 2 + 1
+        len2 = len1 ** 3
+        costall = np.random.rand(2, len2).astype(np.float32)
+        u0 = np.zeros(2, dtype=np.float32)
+        v0 = np.zeros(2, dtype=np.float32)
+        w0 = np.zeros(2, dtype=np.float32)
+        ordered = np.array([0, 1], dtype=np.int32)
+        parents = np.array([0, 0], dtype=np.int32)
+        edgemst = np.ones(2, dtype=np.float32)
+        cu1, cv1, cw1 = gr._regularisation_cpu(costall, u0, v0, w0, hw, 1, 1.0, ordered, parents, edgemst)
+        gu1, gv1, gw1 = gr._regularisation_gpu(
+            gr.cp.asarray(costall),
+            gr.cp.asarray(u0),
+            gr.cp.asarray(v0),
+            gr.cp.asarray(w0),
+            hw,
+            1,
+            1.0,
+            gr.cp.asarray(ordered),
+            gr.cp.asarray(parents),
+            gr.cp.asarray(edgemst),
+        )
+        np.testing.assert_allclose(cu1, gr.cp.asnumpy(gu1), atol=1e-5)
+        np.testing.assert_allclose(cv1, gr.cp.asnumpy(gv1), atol=1e-5)
+        np.testing.assert_allclose(cw1, gr.cp.asnumpy(gw1), atol=1e-5)
+
+        # parity for data cost CL
+        d1 = (np.random.rand(4, 4, 4) * 1e6).astype(np.uint64)
+        d2 = (np.random.rand(4, 4, 4) * 1e6).astype(np.uint64)
+        cpu_dc_cl = gr._data_cost_cl_cpu(d1, d2, step1=1, hw=1, quant=1.0, alpha=0.3)
+        gpu_dc_cl = gr._data_cost_cl_gpu(
+            gr.cp.asarray(d1), gr.cp.asarray(d2), step1=1, hw=1, quant=1.0, alpha=0.3
+        )
+        np.testing.assert_allclose(cpu_dc_cl, gr.cp.asnumpy(gpu_dc_cl))
+
+    def test_cpu_gpu_speed(self):
+        from .. import gpu_registration as gr
+        if not gr._gpu_ok:
+            self.skipTest("GPU not available")
+
+        shape = (512, 512, 51)
+        fixed = np.zeros(shape, dtype=np.float32)
+        rng = np.random.default_rng(0)
+        coords = rng.integers(low=0, high=[shape[0], shape[1], shape[2]], size=(5000, 3))
+        fixed[coords[:, 0], coords[:, 1], coords[:, 2]] = 1.0
+        shift = (3, -2, 1)
+        moving = np.roll(fixed, shift, axis=(0, 1, 2))
+
+        for _ in range(2):
+            gr._phase_corr(fixed, moving, np)
+            cp_f = gr.cp.asarray(fixed)
+            cp_m = gr.cp.asarray(moving)
+            gr._phase_corr(cp_f, cp_m, gr.cp)
+            gr.cp.cuda.runtime.deviceSynchronize()
+
+        start = time.perf_counter()
+        dy, dx, dz = gr._phase_corr(fixed, moving, np)
+        cpu_out = np.roll(moving, shift=(dy, dx, dz), axis=(0, 1, 2))
+        cpu_time = time.perf_counter() - start
+
+        cp_f = gr.cp.asarray(fixed)
+        cp_m = gr.cp.asarray(moving)
+        gr.cp.cuda.runtime.deviceSynchronize()
+        start = time.perf_counter()
+        dy2, dx2, dz2 = gr._phase_corr(cp_f, cp_m, gr.cp)
+        gr.cp.cuda.runtime.deviceSynchronize()
+        shifted = gr.cp.roll(cp_m, shift=(dy2, dx2, dz2), axis=(0, 1, 2))
+        gr.cp.cuda.runtime.deviceSynchronize()
+        gpu_time = time.perf_counter() - start
+        gpu_out = gr.cp.asnumpy(shifted)
+
+        np.testing.assert_allclose(cpu_out, gpu_out, atol=1e-4)
+        self.assertLess(gpu_time, cpu_time)
+        print(f"CPU time: {cpu_time:.4f}s GPU time: {gpu_time:.4f}s")
 
 
-def compute_dice_score(img1, img2, threshold=127):
-    img2.SetOrigin(img1.GetOrigin())
-
-    img1 = sitk.BinaryThreshold(img1, lowerThreshold=threshold)
-    img2 = sitk.BinaryThreshold(img2, lowerThreshold=threshold)
-
-    metrics = sitk.LabelOverlapMeasuresImageFilter()
-    metrics.Execute(img1, img2)
-
-    return metrics.GetDiceCoefficient()
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "numpy", "SimpleITK"]
+requires = ["setuptools", "wheel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy==1.26.4
-cupy-cuda12x==13.4.1
-scipy==1.12.0
+numpy
+cupy-cuda12x
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-SimpleITK==2.1.1
-cython==0.29.28
-numpy==1.19.5
+numpy==1.26.4
+cupy-cuda12x==13.4.1
+scipy==1.12.0


### PR DESCRIPTION
## Summary
- implement first pass at GPU acceleration deeds algorithm
- add a performance comparison test for CPU vs GPU registration
- warm-up and time both methods on a 512×512×51 volume with random points

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`