### PR TITLE
Improve parallelism and memory cleanup

### DIFF
--- a/deeds/libs/MINDSSCbox.h
+++ b/deeds/libs/MINDSSCbox.h
@@ -8,6 +8,7 @@ void boxfilter(float *input, float *temp1, float *temp2, int hw, int m, int n, i
         temp1[i] = input[i];
     }
 
+    #pragma omp parallel for collapse(2) schedule(static)
     for (int k = 0; k < o; k++)
     {
         for (int j = 0; j < n; j++)
@@ -19,6 +20,7 @@ void boxfilter(float *input, float *temp1, float *temp2, int hw, int m, int n, i
         }
     }
 
+    #pragma omp parallel for collapse(2) schedule(static)
     for (int k = 0; k < o; k++)
     {
         for (int j = 0; j < n; j++)
@@ -38,6 +40,7 @@ void boxfilter(float *input, float *temp1, float *temp2, int hw, int m, int n, i
         }
     }
 
+    #pragma omp parallel for collapse(2) schedule(static)
     for (int k = 0; k < o; k++)
     {
         for (int j = 1; j < n; j++)
@@ -68,6 +71,7 @@ void boxfilter(float *input, float *temp1, float *temp2, int hw, int m, int n, i
         }
     }
 
+    #pragma omp parallel for collapse(2) schedule(static)
     for (int k = 1; k < o; k++)
     {
         for (int j = 0; j < n; j++)
@@ -79,6 +83,7 @@ void boxfilter(float *input, float *temp1, float *temp2, int hw, int m, int n, i
         }
     }
 
+    #pragma omp parallel for collapse(2) schedule(static)
     for (int j = 0; j < n; j++)
     {
         for (int i = 0; i < m; i++)
@@ -101,6 +106,7 @@ void boxfilter(float *input, float *temp1, float *temp2, int hw, int m, int n, i
 
 void imshift(float *input, float *output, int dx, int dy, int dz, int m, int n, int o)
 {
+    #pragma omp parallel for collapse(3) schedule(static)
     for (int k = 0; k < o; k++)
     {
         for (int j = 0; j < n; j++)

--- a/deeds/libs/dataCostD.h
+++ b/deeds/libs/dataCostD.h
@@ -158,6 +158,7 @@ void dataCostCL(uint64_t *data, uint64_t *data2, float *results, int m, int n, i
     int szp = mp * np * op;
     uint64_t *data2p = new uint64_t[szp];
 
+    #pragma omp parallel for collapse(3)
     for (int k = 0; k < op; k++)
     {
         for (int j = 0; j < np; j++)
@@ -252,7 +253,7 @@ void dataCostCL(uint64_t *data, uint64_t *data2, float *results, int m, int n, i
         }
     }
 
-    delete data2p;
+    delete[] data2p;
 
     return;
 }
@@ -270,6 +271,7 @@ void warpImageCL(float *warped, float *im1, float *im1b, float *u1, float *v1, f
 
     interp3(warped, im1, u1, v1, w1, m, n, o, m, n, o, true);
 
+    #pragma omp parallel for collapse(3) reduction(+:ssd,ssd0)
     for (int i = 0; i < m; i++)
     {
         for (int j = 0; j < n; j++)
@@ -294,6 +296,7 @@ void warpAffineS(short *warped, short *input, float *X, float *u1, float *v1, fl
     int n = image_n;
     int o = image_o;
     int sz = m * n * o;
+    #pragma omp parallel for collapse(3)
     for (int k = 0; k < o; k++)
     {
         for (int j = 0; j < n; j++)
@@ -358,6 +361,7 @@ void warpAffine(float *warped, float *input, float *im1b, float *X, float *u1, f
         }
     }
 
+    #pragma omp parallel for collapse(3) reduction(+:ssd,ssd0)
     for (int i = 0; i < m; i++)
     {
         for (int j = 0; j < n; j++)

--- a/deeds/libs/dataCostD.h
+++ b/deeds/libs/dataCostD.h
@@ -269,6 +269,8 @@ void warpImageCL(float *warped, float *im1, float *im1b, float *u1, float *v1, f
     float ssd0 = 0;
     float ssd2 = 0;
 
+
+
     interp3(warped, im1, u1, v1, w1, m, n, o, m, n, o, true);
 
     #pragma omp parallel for collapse(3) reduction(+:ssd,ssd0)
@@ -332,6 +334,7 @@ void warpAffine(float *warped, float *input, float *im1b, float *X, float *u1, f
     float ssd0 = 0;
     float ssd2 = 0;
 
+    #pragma omp parallel for collapse(3)
     for (int k = 0; k < o; k++)
     {
         for (int j = 0; j < n; j++)

--- a/deeds/libs/deedsBCV0.cpp
+++ b/deeds/libs/deedsBCV0.cpp
@@ -67,6 +67,7 @@ void deeds(float *im1, float *im1b, float *warped1, int m, int n, int o, float a
     float thresholdF = -1024;
     float thresholdM = -1024;
 
+    #pragma omp simd
     for (int i = 0; i < sz; i++)
     {
         im1b[i] -= thresholdF;
@@ -102,11 +103,12 @@ void deeds(float *im1, float *im1b, float *warped1, int m, int n, int o, float a
     float *ux = new float[sz];
     float *vx = new float[sz];
     float *wx = new float[sz];
+    #pragma omp simd
     for (int i = 0; i < sz; i++)
     {
-        ux[i] = 0.0;
-        vx[i] = 0.0;
-        wx[i] = 0.0;
+        ux[i] = 0.0f;
+        vx[i] = 0.0f;
+        wx[i] = 0.0f;
     }
     int m2 = 0, n2 = 0, o2 = 0, sz2 = 0;
     int m1 = 0, n1 = 0, o1 = 0, sz1 = 0;
@@ -121,14 +123,15 @@ void deeds(float *im1, float *im1b, float *warped1, int m, int n, int o, float a
     float *u1i = new float[sz2];
     float *v1i = new float[sz2];
     float *w1i = new float[sz2];
+    #pragma omp simd
     for (int i = 0; i < sz2; i++)
     {
-        u1[i] = 0.0;
-        v1[i] = 0.0;
-        w1[i] = 0.0;
-        u1i[i] = 0.0;
-        v1i[i] = 0.0;
-        w1i[i] = 0.0;
+        u1[i] = 0.0f;
+        v1[i] = 0.0f;
+        w1[i] = 0.0f;
+        u1i[i] = 0.0f;
+        v1i[i] = 0.0f;
+        w1i[i] = 0.0f;
     }
 
     float *warped0 = new float[m * n * o];
@@ -272,16 +275,16 @@ void deeds(float *im1, float *im1b, float *warped1, int m, int n, int o, float a
         o2 = o1;
         cout << "\n";
 
-        delete u0;
-        delete v0;
-        delete w0;
-        delete costall;
+        delete[] u0;
+        delete[] v0;
+        delete[] w0;
+        delete[] costall;
 
-        delete parents;
-        delete ordered;
+        delete[] parents;
+        delete[] ordered;
     }
-    delete im1_mind;
-    delete im1b_mind;
+    delete[] im1_mind;
+    delete[] im1b_mind;
     //==========================================================================================
     //==========================================================================================
 
@@ -292,6 +295,7 @@ void deeds(float *im1, float *im1b, float *warped1, int m, int n, int o, float a
     upsampleDeformationsCL(ux, vx, wx, u1, v1, w1, m, n, o, m1, n1, o1);
 
     float *flow = new float[sz1 * 3];
+    #pragma omp simd
     for (int i = 0; i < sz1; i++)
     {
         flow[i] = u1[i];
@@ -303,6 +307,7 @@ void deeds(float *im1, float *im1b, float *warped1, int m, int n, int o, float a
     // WRITE OUTPUT DISPLACEMENT FIELD AND IMAGE
     warpAffine(warped1, im1, im1b, X, ux, vx, wx);
 
+    #pragma omp simd
     for (int i = 0; i < sz; i++)
     {
         warped1[i] += thresholdM;
@@ -386,14 +391,15 @@ void deeds_fields(float *im1, float *im1b, float *warped1, float *ux, float *vx,
     float *u1i = new float[sz2];
     float *v1i = new float[sz2];
     float *w1i = new float[sz2];
+    #pragma omp simd
     for (int i = 0; i < sz2; i++)
     {
-        u1[i] = 0.0;
-        v1[i] = 0.0;
-        w1[i] = 0.0;
-        u1i[i] = 0.0;
-        v1i[i] = 0.0;
-        w1i[i] = 0.0;
+        u1[i] = 0.0f;
+        v1[i] = 0.0f;
+        w1[i] = 0.0f;
+        u1i[i] = 0.0f;
+        v1i[i] = 0.0f;
+        w1i[i] = 0.0f;
     }
 
     float *warped0 = new float[m * n * o];
@@ -537,16 +543,16 @@ void deeds_fields(float *im1, float *im1b, float *warped1, float *ux, float *vx,
         o2 = o1;
         cout << "\n";
 
-        delete u0;
-        delete v0;
-        delete w0;
-        delete costall;
+        delete[] u0;
+        delete[] v0;
+        delete[] w0;
+        delete[] costall;
 
-        delete parents;
-        delete ordered;
+        delete[] parents;
+        delete[] ordered;
     }
-    delete im1_mind;
-    delete im1b_mind;
+    delete[] im1_mind;
+    delete[] im1b_mind;
     //==========================================================================================
     //==========================================================================================
 
@@ -557,6 +563,7 @@ void deeds_fields(float *im1, float *im1b, float *warped1, float *ux, float *vx,
     upsampleDeformationsCL(ux, vx, wx, u1, v1, w1, m, n, o, m1, n1, o1);
 
     float *flow = new float[sz1 * 3];
+    #pragma omp simd
     for (int i = 0; i < sz1; i++)
     {
         flow[i] = u1[i];
@@ -646,14 +653,15 @@ void deeds_imwarp_fields(float *im1, float *im1b, float *warped1, float *ux, flo
     float *u1i = new float[sz2];
     float *v1i = new float[sz2];
     float *w1i = new float[sz2];
+    #pragma omp simd
     for (int i = 0; i < sz2; i++)
     {
-        u1[i] = 0.0;
-        v1[i] = 0.0;
-        w1[i] = 0.0;
-        u1i[i] = 0.0;
-        v1i[i] = 0.0;
-        w1i[i] = 0.0;
+        u1[i] = 0.0f;
+        v1[i] = 0.0f;
+        w1[i] = 0.0f;
+        u1i[i] = 0.0f;
+        v1i[i] = 0.0f;
+        w1i[i] = 0.0f;
     }
 
     float *warped0 = new float[m * n * o];
@@ -797,16 +805,16 @@ void deeds_imwarp_fields(float *im1, float *im1b, float *warped1, float *ux, flo
         o2 = o1;
         cout << "\n";
 
-        delete u0;
-        delete v0;
-        delete w0;
-        delete costall;
+        delete[] u0;
+        delete[] v0;
+        delete[] w0;
+        delete[] costall;
 
-        delete parents;
-        delete ordered;
+        delete[] parents;
+        delete[] ordered;
     }
-    delete im1_mind;
-    delete im1b_mind;
+    delete[] im1_mind;
+    delete[] im1b_mind;
     //==========================================================================================
     //==========================================================================================
 
@@ -817,6 +825,7 @@ void deeds_imwarp_fields(float *im1, float *im1b, float *warped1, float *ux, flo
     upsampleDeformationsCL(ux, vx, wx, u1, v1, w1, m, n, o, m1, n1, o1);
 
     float *flow = new float[sz1 * 3];
+    #pragma omp simd
     for (int i = 0; i < sz1; i++)
     {
         flow[i] = u1[i];
@@ -828,6 +837,7 @@ void deeds_imwarp_fields(float *im1, float *im1b, float *warped1, float *ux, flo
     // WRITE OUTPUT DISPLACEMENT FIELD AND IMAGE
     warpAffine(warped1, im1, im1b, X, ux, vx, wx);
 
+    #pragma omp simd
     for (int i = 0; i < sz; i++)
     {
         warped1[i] += thresholdM;

--- a/deeds/libs/primsMST.h
+++ b/deeds/libs/primsMST.h
@@ -248,10 +248,10 @@ void primsGraph(float *im1, int *ordered, int *parents, float *edgemst, int step
 	}
 	priority.clear();
 
-	delete edgecost;
-	delete index_neighbours;
-	delete levelcount;
-	delete leveloffset;
-	delete vertices;
-	delete level;
+    delete[] edgecost;
+    delete[] index_neighbours;
+    delete[] levelcount;
+    delete[] leveloffset;
+    delete[] vertices;
+    delete[] level;
 }

--- a/deeds/registration.pyx
+++ b/deeds/registration.pyx
@@ -4,6 +4,7 @@ import SimpleITK as sitk
 import numpy as np
 
 cimport numpy as np
+np.import_array()
 
 cdef extern from "libs/deedsBCV0.h":
     void deeds(float *im1, float *im1b, float *warped1, int m, int n, int o, float alpha, int levels, bool verbose)

--- a/deeds/tests/test_profile.py
+++ b/deeds/tests/test_profile.py
@@ -1,0 +1,32 @@
+import unittest
+import cProfile
+import pstats
+import io
+import SimpleITK as sitk
+
+from ..registration import registration
+from .test_registration import load_nifty
+
+
+class TestProfiling(unittest.TestCase):
+    def test_profile_registration(self):
+        fixed = load_nifty('samples/fixed.nii.gz')
+        moving = load_nifty('samples/moving.nii.gz')
+
+        pr = cProfile.Profile()
+        pr.enable()
+        registration(fixed, moving)
+        pr.disable()
+
+        s = io.StringIO()
+        stats = pstats.Stats(pr, stream=s).sort_stats('cumulative')
+        stats.print_stats(10)
+        output = s.getvalue()
+
+        # ensure profiling captured some execution time
+        total_time = sum(v[2] for v in stats.stats.values())
+        self.assertGreater(total_time, 0)
+
+        # ensure profiler produced textual output
+        self.assertTrue(len(output) > 0)
+

--- a/setup.py
+++ b/setup.py
@@ -20,14 +20,14 @@ else:
         USE_AVX2 = False
 
 if platform.system() == 'Windows':
-    extra_compile_args = ["/Ox", "/openmp"]
+    extra_compile_args = ["/Ox", "/openmp", "/arch:AVX", "/fp:fast"]
     if USE_AVX2:
         extra_compile_args.append("/arch:AVX2")
     extra_link_args = []
 else:
-    extra_compile_args = ["-O3", "-fopenmp", "-std=c++11"]
+    extra_compile_args = ["-O3", "-fopenmp", "-std=c++11", "-mavx", "-msse4.2", "-ffast-math"]
     if USE_AVX2:
-        extra_compile_args.extend(["-mavx2", "-msse4.2"])
+        extra_compile_args.append("-mavx2")
     extra_link_args = ['-fopenmp']
 
 sourcefiles = ['deeds/registration.pyx', 'deeds/libs/deedsBCV0.cpp']


### PR DESCRIPTION
## Summary
- clean up mismatched array deletions
- add OpenMP parallel loops in data cost and transformation helpers
- parallelize warp functions with reduction for SSD accumulation
- compile with fast math and AVX/AVX2 optimizations
- add profiling test and validate output

## Testing
- `pip install -e .`
- `pip install numpy SimpleITK`
- `pytest -q`